### PR TITLE
Add support for cURL error codes

### DIFF
--- a/src/API/Framework/Request.php
+++ b/src/API/Framework/Request.php
@@ -199,7 +199,7 @@ abstract class Request {
                 $curl->setCookie($key, $value);
             }
 
-            $error_format = "Instagram Request failed: [%s] [%s] %s";
+            $error_format = "Instagram Request failed: [%s] [%s] %s (Code %s)";
 
             switch($this->getMethod()){
 
@@ -208,7 +208,7 @@ abstract class Request {
                     $data = $curl->get($this->getUrl(), $this->getParams());
 
                     if($curl->curlError){
-                        throw new InstagramException(sprintf($error_format, "GET", $this->getUrl(), $curl->errorMessage));
+                        throw new InstagramException(sprintf($error_format, "GET", $this->getUrl(), $curl->errorMessage, $curl->errorCode));
                     }
 
                     break;
@@ -220,7 +220,7 @@ abstract class Request {
                     $data = $curl->post($this->getUrl(), $this->getParams());
 
                     if($curl->curlError){
-                        throw new InstagramException(sprintf($error_format, "POST", $this->getUrl(), $curl->errorMessage));
+                        throw new InstagramException(sprintf($error_format, "POST", $this->getUrl(), $curl->errorMessage, $curl->errorCode));
                     }
 
                     break;
@@ -228,7 +228,7 @@ abstract class Request {
                 }
 
                 default: {
-                    throw new InstagramException(sprintf($error_format, "UNKNOWN", $this->getUrl(), "Unsupported Request Method"));
+                    throw new InstagramException(sprintf($error_format, "UNKNOWN", $this->getUrl(), "Unsupported Request Method", "0"));
                 }
 
             }


### PR DESCRIPTION
The cURL error message is often very cryptic and might come from other
libraries (such as OpenSSL), and isn't enough to know what went wrong.
Therefore, cURL also has its own internal "error code" to explain what
part of cURL's request went wrong (all of the codes are explained at
https://curl.haxx.se/libcurl/c/libcurl-errors.html). This update adds
support for displaying the cURL error code for proper troubleshooting.

Here's an example of the improved string in action: "SSL read:
error:00000000:lib(0):func(0):reason(0), errno 104 (Code 56)". We can
then easily look up cURL error code 56 and see that it is
"CURLE_RECV_ERROR (56): Failure with receiving network data".